### PR TITLE
Improve overlay scale and interaction

### DIFF
--- a/FoodReminder/FoodReminder.csproj
+++ b/FoodReminder/FoodReminder.csproj
@@ -3,7 +3,7 @@
     <Import Project="Dalamud.Plugin.Bootstrap.targets"/>
 
     <PropertyGroup>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <Description>Food Reminder</Description>
         <PackageProjectUrl>https://github.com/sofia819/ffxiv-food-reminder</PackageProjectUrl>
         <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/FoodReminder/Windows/ConfigWindow.cs
+++ b/FoodReminder/Windows/ConfigWindow.cs
@@ -19,10 +19,7 @@ public class ConfigWindow : Window, IDisposable
     public ConfigWindow(Plugin plugin)
         : base("FoodReminder###FoodReminderConfig")
     {
-        Flags =
-            ImGuiWindowFlags.NoResize
-            | ImGuiWindowFlags.NoScrollbar
-            | ImGuiWindowFlags.NoScrollWithMouse;
+        Flags = ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse;
 
         Size = new Vector2(200, 230);
         SizeCondition = ImGuiCond.Always;

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -47,17 +47,9 @@ public class Overlay : Window, IDisposable
     {
         Flags |= ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoBackground;
         if (configuration.IsOverlayLocked)
-        {
-            Flags |=
-                ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoBackground;
-        }
+            Flags |= ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoMove;
         else
-        {
-            Flags &=
-                ~ImGuiWindowFlags.NoInputs
-                & ~ImGuiWindowFlags.NoMove
-                & ~ImGuiWindowFlags.NoBackground;
-        }
+            Flags &= ~ImGuiWindowFlags.NoInputs & ~ImGuiWindowFlags.NoMove;
     }
 
     public override void Draw()

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -58,8 +58,6 @@ public class Overlay : Window, IDisposable
                 & ~ImGuiWindowFlags.NoMove
                 & ~ImGuiWindowFlags.NoBackground;
         }
-
-        ImGui.PushStyleColor(ImGuiCol.WindowBg, configuration.BackgroundColor);
     }
 
     public override void Draw()
@@ -93,9 +91,7 @@ public class Overlay : Window, IDisposable
                     imageEdge.X + (textSize.X + (12 * configuration.OverlayScale)),
                     imageEdge.Y + (8 * configuration.OverlayScale)
                 ),
-                configuration.IsOverlayLocked
-                    ? ImGui.GetColorU32(configuration.BackgroundColor)
-                    : 0,
+                ImGui.GetColorU32(configuration.BackgroundColor),
                 10f
             );
             imDrawListPtr.AddText(
@@ -130,9 +126,7 @@ public class Overlay : Window, IDisposable
                     topLeft.X + textSize.X + (6 * configuration.OverlayScale),
                     topLeft.Y + textSize.Y + (8 * configuration.OverlayScale)
                 ),
-                configuration.IsOverlayLocked
-                    ? ImGui.GetColorU32(configuration.BackgroundColor)
-                    : 0,
+                ImGui.GetColorU32(configuration.BackgroundColor),
                 10f
             );
             imDrawListPtr.AddText(
@@ -148,10 +142,5 @@ public class Overlay : Window, IDisposable
         }
 
         font.Pop();
-    }
-
-    public override void PostDraw()
-    {
-        ImGui.PopStyleColor();
     }
 }

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -33,6 +33,7 @@ public class Overlay : Window, IDisposable
             | ImGuiWindowFlags.NoScrollbar
             | ImGuiWindowFlags.NoScrollWithMouse;
 
+        Size = new Vector2(260, 80);
         SizeConstraints = new WindowSizeConstraints { MaximumSize = new Vector2(1280, 360) };
         SizeCondition = ImGuiCond.FirstUseEver;
 

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -6,12 +6,11 @@ using ImGuiNET;
 
 namespace FoodReminder.Windows;
 
-public class Overlay
-    : Window, IDisposable
+public class Overlay : Window, IDisposable
 {
-    private const int ImageWidth = 64;
+    private const int ImageWidth = 96;
 
-    private const int ImageHeight = 64;
+    private const int ImageHeight = 96;
 
     private readonly Configuration configuration;
 
@@ -25,15 +24,17 @@ public class Overlay
 
     private bool visible;
 
-    public Overlay(Plugin plugin, Configuration configuration, IFontHandle font, string iconPath) : base(
-        "FoodReminder###Overlay")
+    public Overlay(Plugin plugin, Configuration configuration, IFontHandle font, string iconPath)
+        : base("FoodReminder###Overlay")
     {
         this.configuration = configuration;
-        Flags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar |
-                ImGuiWindowFlags.NoScrollWithMouse;
+        Flags =
+            ImGuiWindowFlags.NoCollapse
+            | ImGuiWindowFlags.NoScrollbar
+            | ImGuiWindowFlags.NoScrollWithMouse;
 
         Size = new Vector2(1040, 400);
-        SizeCondition = ImGuiCond.Once;
+        SizeCondition = ImGuiCond.FirstUseEver;
 
         this.configuration = plugin.Configuration;
         this.font = font;
@@ -77,42 +78,55 @@ public class Overlay
 
         var fontGlobalScale = ImGui.GetIO().FontGlobalScale;
 
-
-        var imageEdge = new Vector2(topLeft.X + (ImageWidth * fontGlobalScale * configuration.OverlayScale),
-                                    topLeft.Y + (ImageHeight * fontGlobalScale * configuration.OverlayScale));
-
+        var imageEdge = new Vector2(
+            topLeft.X + (ImageWidth * fontGlobalScale * configuration.OverlayScale),
+            topLeft.Y + (ImageHeight * fontGlobalScale * configuration.OverlayScale)
+        );
 
         font.Push();
         ImGui.SetWindowFontScale(configuration.OverlayScale);
         var textSize = ImGui.CalcTextSize(eatFood);
         imDrawListPtr.AddRectFilled(
             new Vector2(
-                imageEdge.X + (16 * fontGlobalScale * configuration.OverlayScale),
-                topLeft.Y + (20 * fontGlobalScale * configuration.OverlayScale)
+                imageEdge.X + (26 * fontGlobalScale * configuration.OverlayScale),
+                topLeft.Y + (34 * fontGlobalScale * configuration.OverlayScale)
             ),
             new Vector2(
-                imageEdge.X + textSize.X + (24 * fontGlobalScale * configuration.OverlayScale),
-                imageEdge.Y + textSize.Y
-            ), ImGui.GetColorU32(configuration.BackgroundColor)
+                imageEdge.X + textSize.X + (32 * fontGlobalScale * configuration.OverlayScale),
+                topLeft.Y + textSize.Y + (42 * fontGlobalScale * configuration.OverlayScale)
+            ),
+            ImGui.GetColorU32(configuration.BackgroundColor)
         );
+
         imDrawListPtr.AddText(
-            new Vector2(imageEdge.X + (20 * fontGlobalScale * configuration.OverlayScale),
-                        topLeft.Y + (30 * fontGlobalScale * configuration.OverlayScale)),
+            new Vector2(
+                imageEdge.X + (30 * fontGlobalScale * configuration.OverlayScale),
+                topLeft.Y + (40 * fontGlobalScale * configuration.OverlayScale)
+            ),
             !configuration.IsFlashingEffectEnabled || visible
                 ? ImGui.GetColorU32(configuration.PrimaryTextColor)
                 : ImGui.GetColorU32(configuration.SecondaryTextColor),
-            eatFood);
+            eatFood
+        );
         font.Pop();
 
         if (configuration.ShowIcon && image != null)
         {
-            ImGui.SetCursorPosX(ImGui.GetWindowContentRegionMin().X +
-                                (16 * fontGlobalScale * configuration.OverlayScale));
-            ImGui.SetCursorPosY(ImGui.GetWindowContentRegionMin().Y +
-                                (16 * fontGlobalScale * configuration.OverlayScale));
-            ImGui.Image(image.ImGuiHandle,
-                        new Vector2(ImageWidth * fontGlobalScale * configuration.OverlayScale,
-                                    ImageHeight * fontGlobalScale * configuration.OverlayScale));
+            ImGui.SetCursorPosX(
+                ImGui.GetWindowContentRegionMin().X
+                    + (16 * fontGlobalScale * configuration.OverlayScale)
+            );
+            ImGui.SetCursorPosY(
+                ImGui.GetWindowContentRegionMin().Y
+                    + (16 * fontGlobalScale * configuration.OverlayScale)
+            );
+            ImGui.Image(
+                image.ImGuiHandle,
+                new Vector2(
+                    ImageWidth * fontGlobalScale * configuration.OverlayScale,
+                    ImageHeight * fontGlobalScale * configuration.OverlayScale
+                )
+            );
         }
     }
 }

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -8,9 +8,9 @@ namespace FoodReminder.Windows;
 
 public class Overlay : Window, IDisposable
 {
-    private const int ImageWidth = 96;
-
-    private const int ImageHeight = 96;
+    private const string EatFood = "EAT FOOD";
+    private const int ImageWidth = 60;
+    private const int ImageHeight = 60;
 
     private readonly Configuration configuration;
 
@@ -33,7 +33,7 @@ public class Overlay : Window, IDisposable
             | ImGuiWindowFlags.NoScrollbar
             | ImGuiWindowFlags.NoScrollWithMouse;
 
-        Size = new Vector2(1040, 400);
+        SizeConstraints = new WindowSizeConstraints { MaximumSize = new Vector2(1280, 360) };
         SizeCondition = ImGuiCond.FirstUseEver;
 
         this.configuration = plugin.Configuration;
@@ -45,27 +45,25 @@ public class Overlay : Window, IDisposable
 
     public override void PreDraw()
     {
+        Flags |= ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoBackground;
         if (configuration.IsOverlayLocked)
         {
-            Flags |= ImGuiWindowFlags.NoInputs;
-            Flags |= ImGuiWindowFlags.NoMove;
+            Flags |=
+                ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoBackground;
         }
         else
         {
-            Flags &= ~ImGuiWindowFlags.NoInputs;
-            Flags &= ~ImGuiWindowFlags.NoMove;
+            Flags &=
+                ~ImGuiWindowFlags.NoInputs
+                & ~ImGuiWindowFlags.NoMove
+                & ~ImGuiWindowFlags.NoBackground;
         }
-
-        Flags |= ImGuiWindowFlags.NoTitleBar;
-        Flags |= ImGuiWindowFlags.NoBackground;
     }
 
     public override void Draw()
     {
-        var eatFood = "EAT FOOD";
         var currentTime = DateTime.Now;
-
-        if (configuration.IsFlashingEffectEnabled && currentTime - lastVisibleTime > flashTimeSpan)
+        if (currentTime - lastVisibleTime > flashTimeSpan)
         {
             visible = !visible;
             lastVisibleTime = currentTime;
@@ -76,57 +74,73 @@ public class Overlay : Window, IDisposable
 
         var image = Plugin.TextureProvider.GetFromFile(iconPath).GetWrapOrDefault();
 
-        var fontGlobalScale = ImGui.GetIO().FontGlobalScale;
-
         var imageEdge = new Vector2(
-            topLeft.X + (ImageWidth * fontGlobalScale * configuration.OverlayScale),
-            topLeft.Y + (ImageHeight * fontGlobalScale * configuration.OverlayScale)
+            topLeft.X + (ImageWidth * configuration.OverlayScale),
+            topLeft.Y + (ImageHeight * configuration.OverlayScale)
         );
 
         font.Push();
-        ImGui.SetWindowFontScale(configuration.OverlayScale);
-        var textSize = ImGui.CalcTextSize(eatFood);
-        imDrawListPtr.AddRectFilled(
-            new Vector2(
-                imageEdge.X + (26 * fontGlobalScale * configuration.OverlayScale),
-                topLeft.Y + (34 * fontGlobalScale * configuration.OverlayScale)
-            ),
-            new Vector2(
-                imageEdge.X + textSize.X + (32 * fontGlobalScale * configuration.OverlayScale),
-                topLeft.Y + textSize.Y + (42 * fontGlobalScale * configuration.OverlayScale)
-            ),
-            ImGui.GetColorU32(configuration.BackgroundColor)
-        );
-
-        imDrawListPtr.AddText(
-            new Vector2(
-                imageEdge.X + (30 * fontGlobalScale * configuration.OverlayScale),
-                topLeft.Y + (40 * fontGlobalScale * configuration.OverlayScale)
-            ),
-            !configuration.IsFlashingEffectEnabled || visible
-                ? ImGui.GetColorU32(configuration.PrimaryTextColor)
-                : ImGui.GetColorU32(configuration.SecondaryTextColor),
-            eatFood
-        );
-        font.Pop();
+        ImGui.SetWindowFontScale(configuration.OverlayScale * 1 / ImGui.GetIO().FontGlobalScale);
+        var textSize = ImGui.CalcTextSize(EatFood);
 
         if (configuration.ShowIcon && image != null)
         {
+            imDrawListPtr.AddRectFilled(
+                topLeft,
+                new Vector2(
+                    imageEdge.X + (textSize.X + (12 * configuration.OverlayScale)),
+                    imageEdge.Y + (8 * configuration.OverlayScale)
+                ),
+                ImGui.GetColorU32(configuration.BackgroundColor),
+                10f
+            );
+            imDrawListPtr.AddText(
+                new Vector2(
+                    imageEdge.X + (8 * configuration.OverlayScale),
+                    topLeft.Y + (10 * configuration.OverlayScale)
+                ),
+                !configuration.IsFlashingEffectEnabled || visible
+                    ? ImGui.GetColorU32(configuration.PrimaryTextColor)
+                    : ImGui.GetColorU32(configuration.SecondaryTextColor),
+                EatFood
+            );
             ImGui.SetCursorPosX(
-                ImGui.GetWindowContentRegionMin().X
-                    + (16 * fontGlobalScale * configuration.OverlayScale)
+                ImGui.GetWindowContentRegionMin().X + (4 * configuration.OverlayScale)
             );
             ImGui.SetCursorPosY(
-                ImGui.GetWindowContentRegionMin().Y
-                    + (16 * fontGlobalScale * configuration.OverlayScale)
+                ImGui.GetWindowContentRegionMin().Y + (4 * configuration.OverlayScale)
             );
             ImGui.Image(
                 image.ImGuiHandle,
                 new Vector2(
-                    ImageWidth * fontGlobalScale * configuration.OverlayScale,
-                    ImageHeight * fontGlobalScale * configuration.OverlayScale
+                    ImageWidth * configuration.OverlayScale,
+                    ImageHeight * configuration.OverlayScale
                 )
             );
         }
+        else
+        {
+            imDrawListPtr.AddRectFilled(
+                topLeft,
+                new Vector2(
+                    topLeft.X + textSize.X + (6 * configuration.OverlayScale),
+                    topLeft.Y + textSize.Y + (8 * configuration.OverlayScale)
+                ),
+                ImGui.GetColorU32(configuration.BackgroundColor),
+                10f
+            );
+            imDrawListPtr.AddText(
+                new Vector2(
+                    topLeft.X + (4 * configuration.OverlayScale),
+                    topLeft.Y + (4 * configuration.OverlayScale)
+                ),
+                !configuration.IsFlashingEffectEnabled || visible
+                    ? ImGui.GetColorU32(configuration.PrimaryTextColor)
+                    : ImGui.GetColorU32(configuration.SecondaryTextColor),
+                EatFood
+            );
+        }
+
+        font.Pop();
     }
 }

--- a/FoodReminder/Windows/Overlay.cs
+++ b/FoodReminder/Windows/Overlay.cs
@@ -58,6 +58,8 @@ public class Overlay : Window, IDisposable
                 & ~ImGuiWindowFlags.NoMove
                 & ~ImGuiWindowFlags.NoBackground;
         }
+
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, configuration.BackgroundColor);
     }
 
     public override void Draw()
@@ -91,7 +93,9 @@ public class Overlay : Window, IDisposable
                     imageEdge.X + (textSize.X + (12 * configuration.OverlayScale)),
                     imageEdge.Y + (8 * configuration.OverlayScale)
                 ),
-                ImGui.GetColorU32(configuration.BackgroundColor),
+                configuration.IsOverlayLocked
+                    ? ImGui.GetColorU32(configuration.BackgroundColor)
+                    : 0,
                 10f
             );
             imDrawListPtr.AddText(
@@ -126,7 +130,9 @@ public class Overlay : Window, IDisposable
                     topLeft.X + textSize.X + (6 * configuration.OverlayScale),
                     topLeft.Y + textSize.Y + (8 * configuration.OverlayScale)
                 ),
-                ImGui.GetColorU32(configuration.BackgroundColor),
+                configuration.IsOverlayLocked
+                    ? ImGui.GetColorU32(configuration.BackgroundColor)
+                    : 0,
                 10f
             );
             imDrawListPtr.AddText(
@@ -142,5 +148,10 @@ public class Overlay : Window, IDisposable
         }
 
         font.Pop();
+    }
+
+    public override void PostDraw()
+    {
+        ImGui.PopStyleColor();
     }
 }

--- a/FoodReminder/Windows/StyleTab.cs
+++ b/FoodReminder/Windows/StyleTab.cs
@@ -46,7 +46,7 @@ public class StyleTab(Configuration configuration)
             }
 
             var overlayScale = Configuration.OverlayScale;
-            if (ImGui.DragFloat("Scale", ref overlayScale, 0.01f, 0.2f, 3.0f))
+            if (ImGui.DragFloat("Scale", ref overlayScale, 0.01f, 0.2f, 5.0f))
             {
                 Configuration.OverlayScale = overlayScale;
                 Configuration.Save();


### PR DESCRIPTION
## Description
- Ignore global font scale when showing the overlay
- Allow resizing of overlay window, since it will block input when it is not locked
- Draw rectangle around the entire overlay, as opposed to only around the text